### PR TITLE
Update release workflow to enhance release creation and artifact uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,14 +99,14 @@ jobs:
           echo "version=v$VERSION" >> $GITHUB_OUTPUT
         fi
         
-    - name: Create Release
+    - name: Create or Update Release
       id: create_release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ steps.get_version.outputs.version }}
-        release_name: RockApiClient ${{ steps.get_version.outputs.version }}
+        name: RockApiClient ${{ steps.get_version.outputs.version }}
         body: |
           ## 🚀 RockApiClient ${{ steps.get_version.outputs.version }}
           
@@ -157,83 +157,12 @@ jobs:
           Check out our [documentation](https://github.com/${{ github.repository }}) for detailed usage instructions.
         draft: false
         prerelease: false
-        
-    - name: Upload macOS DMG (ARM64)
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/electron-app-mac/dist/RockApiClient-1.0.0-arm64.dmg
-        asset_name: RockApiClient-${{ steps.get_version.outputs.version }}-arm64.dmg
-        asset_content_type: application/octet-stream
-        
-    - name: Upload macOS DMG (x64)
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/electron-app-mac/dist/RockApiClient-1.0.0-x64.dmg
-        asset_name: RockApiClient-${{ steps.get_version.outputs.version }}-x64.dmg
-        asset_content_type: application/octet-stream
-        
-    - name: Upload macOS ZIP (ARM64)
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/electron-app-mac/dist/RockApiClient-1.0.0-arm64.zip
-        asset_name: RockApiClient-${{ steps.get_version.outputs.version }}-arm64.zip
-        asset_content_type: application/zip
-        
-    - name: Upload macOS ZIP (x64)
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/electron-app-mac/dist/RockApiClient-1.0.0-x64.zip
-        asset_name: RockApiClient-${{ steps.get_version.outputs.version }}-x64.zip
-        asset_content_type: application/zip
-        
-    - name: Upload Windows installer
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/electron-app-win/dist/RockApiClient Setup 1.0.0.exe
-        asset_name: RockApiClient-${{ steps.get_version.outputs.version }}-setup.exe
-        asset_content_type: application/octet-stream
-        
-    - name: Upload Windows zip
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/electron-app-win/dist/RockApiClient-1.0.0-win.zip
-        asset_name: RockApiClient-${{ steps.get_version.outputs.version }}-win.zip
-        asset_content_type: application/zip
-        
-    - name: Upload Linux AppImage
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/electron-app-linux/dist/RockApiClient-1.0.0.AppImage
-        asset_name: RockApiClient-${{ steps.get_version.outputs.version }}.AppImage
-        asset_content_type: application/octet-stream
-        
-    - name: Upload Linux deb
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/electron-app-linux/dist/rock-api-client_1.0.0_amd64.deb
-        asset_name: RockApiClient-${{ steps.get_version.outputs.version }}.deb
-        asset_content_type: application/vnd.debian.binary-package
+        files: |
+          artifacts/electron-app-mac/dist/RockApiClient-1.0.0-arm64.dmg
+          artifacts/electron-app-mac/dist/RockApiClient-1.0.0-x64.dmg
+          artifacts/electron-app-mac/dist/RockApiClient-1.0.0-arm64.zip
+          artifacts/electron-app-mac/dist/RockApiClient-1.0.0-x64.zip
+          artifacts/electron-app-win/dist/RockApiClient Setup 1.0.0.exe
+          artifacts/electron-app-win/dist/RockApiClient-1.0.0-win.zip
+          artifacts/electron-app-linux/dist/RockApiClient-1.0.0.AppImage
+          artifacts/electron-app-linux/dist/rock-api-client_1.0.0_amd64.deb


### PR DESCRIPTION
- Changed the action used for creating releases from `actions/create-release@v1` to `softprops/action-gh-release@v1` for improved functionality.
- Renamed the release step to "Create or Update Release" for clarity.
- Consolidated artifact uploads into a single step by specifying multiple files, streamlining the release process for macOS, Windows, and Linux builds.